### PR TITLE
Adding TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+type DependencyList = ReadonlyArray<any>;
+
+declare function useMemoOne<T>(
+  // getResult changes on every call,
+  getResult: () => T,
+  // the inputs array changes on every call
+  inputs: DependencyList | undefined,
+): T;
+
+declare function useCallbackOne<T extends (...args: any[]) => any>(
+  // getResult changes on every call,
+  callback: T,
+  // the inputs array changes on every call
+  inputs: DependencyList | undefined,
+): T;
+
+export { useMemoOne, useCallbackOne };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "sideEffects": false,
   "files": [
     "/dist",
-    "/src"
+    "/src",
+    "index.d.ts"
   ],
   "author": "Alex Reardon <alexreardon@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
- I've checked it locally with `yarn link`
- [TS reference](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1021)
- In TS typings `useCallbackOne`'s `deps` / `inputs` aren't optional / undefined. But since in Flow file it's optional, I've did it optional too