### PR TITLE
Remove unnecessary input from committing useEffect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export function useMemoOne<T>(
   // commit the cache
   useEffect(() => {
     committed.current = cache;
-  }, [cache]);
+  });
 
   return cache.result;
 }


### PR DESCRIPTION
These inputs were unnecessary as you already preserve the cache before that effect. So it really doesn't matter much, because even without these inputs u just reassign the same value - so it's basically noop.

Removing this yields to tiny size improvement and fewer array allocations when using this hook.