### PR TITLE
fix: never call "getResult" more than once per render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,9 @@ export function useMemoOne<T>(
   }));
 
   const committed = useRef<Cache<T>>();
+  const prevCache = committed.current;
 
-  let cache = committed.current;
+  let cache = prevCache;
   if (cache) {
     const useCache = Boolean(
       inputs && cache.inputs && areInputsEqual(inputs, cache.inputs),
@@ -40,6 +41,10 @@ export function useMemoOne<T>(
   // commit the cache
   useEffect(() => {
     committed.current = cache;
+    if (prevCache == initial) {
+      // clear the initial cache to free memory
+      initial.inputs = initial.result = undefined;
+    }
   }, [cache]);
 
   return cache.result;

--- a/src/index.js
+++ b/src/index.js
@@ -14,28 +14,28 @@ export function useMemoOne<T>(
   inputs?: mixed[],
 ): T {
   // using useState to generate initial value as it is lazy
-  const initial: Cache<T> = useState(() => ({
+  const [initial] = useState((): Cache<T> => ({
     inputs,
     result: getResult(),
-  }))[0];
+  }));
 
-  const committed = useRef<Cache<T>>(initial);
+  const committed = useRef<Cache<T>>();
 
-  // persist any uncommitted changes after they have been committed
-
-  const isInputMatch: boolean = Boolean(
-    inputs &&
-      committed.current.inputs &&
-      areInputsEqual(inputs, committed.current.inputs),
-  );
-
-  // create a new cache if required
-  const cache: Cache<T> = isInputMatch
-    ? committed.current
-    : {
+  let cache = committed.current;
+  if (cache) {
+    const useCache = Boolean(
+      inputs && cache.inputs && areInputsEqual(inputs, cache.inputs),
+    );
+    // create a new cache if required
+    if (!useCache) {
+      cache = {
         inputs,
         result: getResult(),
       };
+    }
+  } else {
+    cache = initial;
+  }
 
   // commit the cache
   useEffect(() => {

--- a/test/no-input.spec.js
+++ b/test/no-input.spec.js
@@ -75,3 +75,15 @@ it('should start memoizing if inputs are provided', () => {
   // reference changed
   expect(fourth).not.toBe(third);
 });
+
+it('should only call get result once on first pass', () => {
+  const getResult = jest.fn();
+  const wrapper = mount(
+    <WithMemo getResult={getResult} inputs={null}>
+      {() => null}
+    </WithMemo>,
+  );
+
+  // initial call
+  expect(getResult).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
**The problem:** When the `inputs` are undefined, the `getResult` function is called *twice* on the first render.

**The solution:** Pass nothing as the initial value of the `committed` ref, so we can distinguish the first render from every other render. Then assume the `cache` is "current" when `committed.current` is undefined.